### PR TITLE
gui: re-enable on-device CODEX32 seed entry

### DIFF
--- a/gui/codex32_input_test.go
+++ b/gui/codex32_input_test.go
@@ -1,0 +1,45 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+
+	"seedhammer.com/codex32"
+)
+
+// Drives the "Input Seed" menu to the CODEX32 choice (index 2) and enters a
+// valid codex32 string on the keypad, asserting newInputFlow returns it.
+//
+// Without "CODEX32" in the menu this does NOT pass: with only two choices the
+// Down-key selection caps at index 1 ("24 WORDS"), so the run enters 24-word
+// BIP-39 input which never completes on a codex32 string and the test fails via
+// the test timeout — it never reaches the codex32 path. With "CODEX32" added,
+// index 2 routes to inputCodex32Flow, which returns the entered codex32 string.
+//
+// NOTE: the keypad stores typed runes UPPERCASE, so the returned string is the
+// uppercase form of what we type; compare against strings.ToUpper(share).
+func TestInputSeedCodex32(t *testing.T) {
+	// A valid "ms" codex32 string from the codex32 package's own test corpus.
+	const share = "ms10testsxxxxxxxxxxxxxxxxxxxxxxxxxx4nzvca9cmczlw"
+
+	ctx := NewContext(newPlatform())
+	// Menu: move the selection 0 -> 2 (CODEX32) with two Down presses, confirm
+	// with Button3 (the ChoiceScreen "choose" button).
+	click(&ctx.Router, Down, Down, Button3)
+	// Keypad: type the share, then confirm with Button2 (OK).
+	runes(&ctx.Router, share)
+	click(&ctx.Router, Button2)
+
+	obj, ok := newInputFlow(ctx, &descriptorTheme)
+	if !ok {
+		t.Fatal("newInputFlow did not return a value")
+	}
+	s, isCodex := obj.(codex32.String)
+	if !isCodex {
+		t.Fatalf("newInputFlow returned %T, want codex32.String", obj)
+	}
+	want := strings.ToUpper(share) // keypad uppercases typed runes
+	if got := s.String(); got != want {
+		t.Errorf("codex32 entry returned %q, want %q", got, want)
+	}
+}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1803,7 +1803,7 @@ func newInputFlow(ctx *Context, th *Colors) (any, bool) {
 		cs := &ChoiceScreen{
 			Title:   "Input Seed",
 			Lead:    "Choose number of words",
-			Choices: []string{"12 WORDS", "24 WORDS" /* , "CODEX32", "SLIP-39" */},
+			Choices: []string{"12 WORDS", "24 WORDS", "CODEX32" /* , "SLIP-39" */},
 		}
 		for {
 			choice, ok := cs.Choose(ctx, th)


### PR DESCRIPTION
## Summary
- Re-enables the `CODEX32` choice in the **Input Seed** menu (`newInputFlow`). The handler (`case 2:` → `inputCodex32Flow`) and the keypad flow are already implemented and were sitting behind a `// TODO: re-enable`. One line of production code.
- Adds `gui/codex32_input_test.go`, a host test that drives the menu to the CODEX32 choice and enters a valid codex32 string, asserting `newInputFlow` returns the `codex32.String`.

## Why
Lets users hand-enter a BIP-93 codex32 secret directly on the air-gapped device instead of importing it — the secure path for secret material.

## Test plan
- [x] `go test ./gui/` passes (incl. the new `TestInputSeedCodex32` and existing flows).
- [x] `go vet ./gui/` and `gofmt` clean.

## Contact
Happy to discuss — I'm `bg002h.66` on Signal (SeedHammer community).