### PR TITLE
codex32+gui: BCH-validated md1/mk1 engraving

### DIFF
--- a/codex32/mdmk.go
+++ b/codex32/mdmk.go
@@ -1,5 +1,7 @@
 package codex32
 
+import "strings"
+
 // md1 (HRP "md") and mk1 (HRP "mk") are sibling formats that reuse codex32's
 // BCH machinery (the BIP-93 BCH(93,80,8) regular code and BCH(108,93,8) long
 // code) with NUMS-derived target residues and a NON-codex32 initial residue.
@@ -89,7 +91,9 @@ func unpackSyms(hi, lo uint64, n int) []fe {
 // Pure verify, no error correction.
 func verifyMDMK(s, hrp string, generator []fe, targetHi, targetLo uint64, n int) bool {
 	gotHRP, data := splitHRP(s)
-	if gotHRP != hrp {
+	// Case-insensitive HRP match, like codex32.New: a consistently upper- or
+	// lower-cased string is valid; mixed case is rejected below by the engine.
+	if !strings.EqualFold(gotHRP, hrp) {
 		return false
 	}
 	// A valid string carries at least the n-symbol checksum in its data part.
@@ -101,7 +105,10 @@ func verifyMDMK(s, hrp string, generator []fe, targetHi, targetLo uint64, n int)
 		residue:   unpackSyms(0, mdmkPolymodInitLo, n), // POLYMOD_INIT — NOT codex32's 1
 		target:    unpackSyms(targetHi, targetLo, n),
 	}
-	if err := e.inputHRP(hrp); err != nil {
+	// Feed the ORIGINAL-cased HRP (not the lowercase literal) so the engine's
+	// case state matches the data; this is what makes uppercase strings validate
+	// and mixed-case ones fail (errInvalidCase), exactly like codex32.New.
+	if err := e.inputHRP(gotHRP); err != nil {
 		return false
 	}
 	if err := e.inputData(data); err != nil {

--- a/codex32/mdmk.go
+++ b/codex32/mdmk.go
@@ -1,0 +1,142 @@
+package codex32
+
+// md1 (HRP "md") and mk1 (HRP "mk") are sibling formats that reuse codex32's
+// BCH machinery (the BIP-93 BCH(93,80,8) regular code and BCH(108,93,8) long
+// code) with NUMS-derived target residues and a NON-codex32 initial residue.
+//
+// CRITICAL: the md/mk BCH initial residue is POLYMOD_INIT = 0x23181b3, NOT
+// codex32's 1. Copying newShortChecksum's residue field and only swapping
+// target would compute every checksum against the wrong starting state and
+// silently mis-validate. The parity test (mdmk_test.go) against Rust-sourced
+// golden vectors is the guard against that bug.
+//
+// This is a PURE verifier: it rejects corruption but performs no error
+// correction (unlike mk-codec's decode_string, which auto-corrects up to t=4
+// substitutions). The string is engraved verbatim; we only reject corruption.
+//
+// Constants (sources of truth, verified against the Rust codecs in recon and by
+// the parity test; bit widths confirmed):
+//
+//	POLYMOD_INIT      = 0x23181b3             (26 bits) — both md-codec & mk-codec bch.rs
+//	MD regular target = 0x0815c07747a3392e7   (64 bits) — descriptor-mnemonic md-codec bch.rs:17
+//	MK regular target = 0x1062435f91072fa5c   (65 bits) — mnemonic-key consts.rs:18
+//	MK long target    = 0x41890d7e441cbe97273 (75 bits) — mnemonic-key consts.rs:21
+//
+// 65- and 75-bit targets do not fit a single uint64, so they are passed to
+// unpackSyms as a hi/lo uint64 pair:
+//
+//	MK regular: hi=0x1,   lo=0x62435f91072fa5c   (0x1<<64   | lo == 0x1062435f91072fa5c)
+//	MK long:    hi=0x418, lo=0x90d7e441cbe97273  (0x418<<64 | lo == 0x41890d7e441cbe97273)
+//
+// md1 is regular-only (md-codec dropped the long code). TinyGo-safe: uint64 only,
+// no math/big.
+
+const (
+	// mdmkPolymodInitLo is the md/mk BCH initial residue POLYMOD_INIT (< 2^64,
+	// so hi is 0). It replaces codex32's initial residue of 1.
+	mdmkPolymodInitLo uint64 = 0x23181b3
+
+	mdmkShortSyms = 13 // regular code: 13-symbol checksum (BCH(93,80,8))
+	mdmkLongSyms  = 15 // long code: 15-symbol checksum (BCH(108,93,8))
+
+	// MK data-part length gate, from mk-codec's bch_code_for_length
+	// (mnemonic-key string_layer/bch.rs:117): regular for 14..=93, long for
+	// 96..=108, with 94..=95 and out-of-range lengths reserved-invalid.
+	mkRegularMinLen = 14
+	mkRegularMaxLen = 93
+	mkLongMinLen    = 96
+	mkLongMaxLen    = 108
+)
+
+// md/mk NUMS target residues, split into hi/lo uint64 pairs for unpackSyms.
+const (
+	mdRegularTargetHi uint64 = 0x0
+	mdRegularTargetLo uint64 = 0x0815c07747a3392e7
+
+	mkRegularTargetHi uint64 = 0x1
+	mkRegularTargetLo uint64 = 0x62435f91072fa5c
+
+	mkLongTargetHi uint64 = 0x418
+	mkLongTargetLo uint64 = 0x90d7e441cbe97273
+)
+
+// unpackSyms returns n 5-bit GF(32) symbols of (hi<<64 | lo), MSB-first
+// (symbol 0 = the top 5 bits). This matches the codex32 engine's residue/target
+// layout, where index 0 is the highest power. hi is 0 for any value < 2^64.
+func unpackSyms(hi, lo uint64, n int) []fe {
+	out := make([]fe, n)
+	for i := 0; i < n; i++ {
+		shift := uint(5 * (n - 1 - i))
+		var v uint64
+		switch {
+		case shift >= 64:
+			v = hi >> (shift - 64)
+		case shift == 0:
+			v = lo
+		default:
+			v = (lo >> shift) | (hi << (64 - shift))
+		}
+		out[i] = fe(v & 0x1f)
+	}
+	return out
+}
+
+// verifyMDMK validates s against the given HRP, generator, and target residue,
+// using the md/mk initial residue (POLYMOD_INIT) for an n-symbol checksum (13
+// regular / 15 long). It mirrors codex32.New's verify path: split off the HRP,
+// feed inputHRP + inputData (the engine decodes runes internally, so the data
+// part is passed as a string, not a pre-decoded []fe), then check isValid.
+// Pure verify, no error correction.
+func verifyMDMK(s, hrp string, generator []fe, targetHi, targetLo uint64, n int) bool {
+	gotHRP, data := splitHRP(s)
+	if gotHRP != hrp {
+		return false
+	}
+	// A valid string carries at least the n-symbol checksum in its data part.
+	if len(data) < n {
+		return false
+	}
+	e := &engine{
+		generator: generator,
+		residue:   unpackSyms(0, mdmkPolymodInitLo, n), // POLYMOD_INIT — NOT codex32's 1
+		target:    unpackSyms(targetHi, targetLo, n),
+	}
+	if err := e.inputHRP(hrp); err != nil {
+		return false
+	}
+	if err := e.inputData(data); err != nil {
+		return false
+	}
+	return e.isValid()
+}
+
+// ValidMD reports whether s is a structurally valid, BCH-correct md1 string.
+// md1 uses the regular code only (md-codec dropped the long code). The data part
+// must be at least the 13-symbol checksum; md-codec applies no further data-part
+// length bracket (md-codec codex32.rs:144-155).
+func ValidMD(s string) bool {
+	return verifyMDMK(s, "md", newShortChecksum().generator,
+		mdRegularTargetHi, mdRegularTargetLo, mdmkShortSyms)
+}
+
+// ValidMK reports whether s is a structurally valid, BCH-correct mk1 string,
+// regular (13-symbol checksum) or long (15-symbol checksum). The regular/long
+// selection and the rejection of out-of-bracket lengths follow mk-codec's
+// bch_code_for_length (mnemonic-key string_layer/bch.rs:117), keyed on the
+// data-part length (the chars after "mk1"). Lengths 94..=95 and anything
+// outside 14..=108 are reserved-invalid and rejected here (not corrected),
+// because this verifier does no error correction.
+func ValidMK(s string) bool {
+	_, data := splitHRP(s)
+	switch n := len(data); {
+	case n >= mkRegularMinLen && n <= mkRegularMaxLen:
+		return verifyMDMK(s, "mk", newShortChecksum().generator,
+			mkRegularTargetHi, mkRegularTargetLo, mdmkShortSyms)
+	case n >= mkLongMinLen && n <= mkLongMaxLen:
+		return verifyMDMK(s, "mk", newLongChecksum().generator,
+			mkLongTargetHi, mkLongTargetLo, mdmkLongSyms)
+	default:
+		// 94..=95 reserved-invalid, or out of the BIP-93 valid range.
+		return false
+	}
+}

--- a/codex32/mdmk_test.go
+++ b/codex32/mdmk_test.go
@@ -74,12 +74,28 @@ func TestMDMKRejectsAllZeros(t *testing.T) {
 }
 
 func TestMDMKLengthBracket(t *testing.T) {
-	// Data-part lengths in the reserved gap (94..95) or out of range are rejected.
-	if ValidMK("mk1" + strings.Repeat("q", 94)) {
-		t.Error("mk1 with reserved-gap (94) data length accepted")
+	// Out-of-bracket data-part lengths are rejected: too-short (<14), the
+	// reserved gap (94, 95), and just over the long-code max (109). Matches
+	// mk-codec bch_code_for_length (regular 14..93, long 96..108).
+	for _, n := range []int{5, 94, 95, 109} {
+		if ValidMK("mk1" + strings.Repeat("q", n)) {
+			t.Errorf("mk1 with out-of-bracket data length %d accepted", n)
+		}
 	}
-	if ValidMK("mk1" + strings.Repeat("q", 5)) {
-		t.Error("mk1 with too-short data length accepted")
+}
+
+func TestMDMKCaseHandling(t *testing.T) {
+	// Consistent uppercase validates (BIP-173 / codex32 case-tolerance).
+	if !ValidMD(strings.ToUpper(md1Regular)) {
+		t.Error("uppercase md1 rejected; verifyMDMK must be case-tolerant like codex32.New")
+	}
+	if !ValidMK(strings.ToUpper(mk1Regular)) {
+		t.Error("uppercase mk1 rejected")
+	}
+	// Mixed case (lowercase HRP + uppercase data) is rejected.
+	mixed := "md1" + strings.ToUpper(md1Regular[len("md1"):])
+	if ValidMD(mixed) {
+		t.Errorf("mixed-case md1 %q accepted", mixed)
 	}
 }
 

--- a/codex32/mdmk_test.go
+++ b/codex32/mdmk_test.go
@@ -1,0 +1,105 @@
+package codex32
+
+import (
+	"strings"
+	"testing"
+)
+
+// Golden vectors are RUST-SOURCED (md-codec 0.36 / mk-codec v0.1.json), never
+// Go-self-generated — they are the only guard against a wrong initial residue
+// (POLYMOD_INIT vs codex32's 1). mk1Long has a 108-char data part (the 15-symbol
+// long code, BCH(108,93,8)); mk1Regular has a 77-char data part (regular code).
+const (
+	md1Regular = "md1yqpqqxqq8xtwhw4xwn4qh"
+	mk1Regular = "mk1qpzg69ppsnz4v7cjv3qfjhf76k4t5pt96u0psdrqfqvll8qh7h5athg837pmkf3dpug2mmjtfel6x"
+	mk1Long    = "mk1qp0zgpzp3xqgpqqgqjyty8ssyqcq0tdd4kk6mtdd4kk6mtdd4kk6mtdd4kk6mtdd4kk6mtdd4kk6mtddq2vfczmkedtrj2rjl6la2h9ek48q"
+)
+
+func TestMDMKValid(t *testing.T) {
+	if !ValidMD(md1Regular) {
+		t.Error("ValidMD rejected a valid md1 (check POLYMOD_INIT / md target)")
+	}
+	if !ValidMK(mk1Regular) {
+		t.Error("ValidMK rejected a valid regular mk1 (check mk regular target hi/lo)")
+	}
+	if !ValidMK(mk1Long) {
+		t.Error("ValidMK rejected a valid long mk1 (check long code path + mk long target hi/lo)")
+	}
+}
+
+func TestMDMKWrongHRP(t *testing.T) {
+	if ValidMD(mk1Regular) {
+		t.Error("ValidMD accepted an mk1 string")
+	}
+	if ValidMK(md1Regular) {
+		t.Error("ValidMK accepted an md1 string")
+	}
+}
+
+func TestMDMKRejectsTamper(t *testing.T) {
+	// A single flipped data symbol must be REJECTED — this is a pure verifier,
+	// no error correction (unlike mk-codec's decode_string, which auto-corrects).
+	flipLast := func(s string) string {
+		b := []byte(s)
+		i := len(b) - 1
+		if b[i] == 'q' {
+			b[i] = 'p'
+		} else {
+			b[i] = 'q'
+		}
+		return string(b)
+	}
+	if ValidMD(flipLast(md1Regular)) {
+		t.Error("tampered md1 accepted")
+	}
+	if ValidMK(flipLast(mk1Regular)) {
+		t.Error("tampered mk1 accepted")
+	}
+	if ValidMK(flipLast(mk1Long)) {
+		t.Error("tampered long mk1 accepted")
+	}
+}
+
+func TestMDMKRejectsAllZeros(t *testing.T) {
+	// All-"q" (zero) data of a valid regular length must not self-validate
+	// (NUMS-derived target — anti-trivial property).
+	mdDataLen := len(md1Regular) - 3
+	if ValidMD("md1" + strings.Repeat("q", mdDataLen)) {
+		t.Error("all-zero md1 self-validated")
+	}
+	mkDataLen := len(mk1Regular) - 3
+	if ValidMK("mk1" + strings.Repeat("q", mkDataLen)) {
+		t.Error("all-zero mk1 self-validated")
+	}
+}
+
+func TestMDMKLengthBracket(t *testing.T) {
+	// Data-part lengths in the reserved gap (94..95) or out of range are rejected.
+	if ValidMK("mk1" + strings.Repeat("q", 94)) {
+		t.Error("mk1 with reserved-gap (94) data length accepted")
+	}
+	if ValidMK("mk1" + strings.Repeat("q", 5)) {
+		t.Error("mk1 with too-short data length accepted")
+	}
+}
+
+func TestMDMKNoPanicOnMalformed(t *testing.T) {
+	// verifyMDMK must REJECT (return false) and never panic on malformed input:
+	// no separator, empty, empty/short data, invalid bech32 chars (b/i/o/!),
+	// mixed case, and over-long strings.
+	for _, s := range []string{
+		"", "1", "md1", "mk1", "noseparator", "md", "mk",
+		"md1!!!", "mk1qqq i o b",
+		"md1" + strings.Repeat("q", 20) + "b", // len-OK data with an invalid char
+		"MD1qPqQ",                             // mixed case
+		"md1" + strings.Repeat("q", 300),      // very long
+		"mk1" + strings.Repeat("q", 300),
+	} {
+		if ValidMD(s) {
+			t.Errorf("ValidMD(%q) = true, want false", s)
+		}
+		if ValidMK(s) {
+			t.Errorf("ValidMK(%q) = true, want false", s)
+		}
+	}
+}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1786,8 +1786,9 @@ func validateMdmk(params engrave.Params, s string) ([]string, []Plate, error) {
 func mdmkFlow(ctx *Context, th *Colors, s mdmkText) {
 	labels, engravings, err := validateMdmk(ctx.Platform.EngraverParams(), string(s))
 	if err != nil {
-		// Only reached if no mode fits a plate (rare for an md1/mk1 string);
-		// like descriptorFlow's siblings, bail rather than engrave nothing.
+		// Only reached if no engraving variant fits a plate (rare for an md1/mk1
+		// string). Return silently — like backupSeedStringFlow, NOT like
+		// descriptorFlow (whose ErrorScreen "Too Large" copy is descriptor-specific).
 		return
 	}
 	cs := &ChoiceScreen{Title: "Engrave", Lead: "Choose engraving", Choices: labels}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1731,10 +1731,75 @@ func engraveObjectFlow(ctx *Context, th *Colors, obj any) bool {
 		backupSeedStringFlow(ctx, th, s)
 	case *bip380.Descriptor:
 		descriptorFlow(ctx, th, scan)
+	case mdmkText:
+		mdmkFlow(ctx, th, scan)
 	default:
 		return false
 	}
 	return true
+}
+
+// validateMdmk lays out an md1/mk1 string as TEXT+QR / TEXT / QR-ONLY plates,
+// mirroring validateDescriptor but engraving the string verbatim (the QR
+// payload is the string itself). Modes that don't fit a plate are dropped; an
+// error is returned only if none fit.
+func validateMdmk(params engrave.Params, s string) ([]string, []Plate, error) {
+	qrc, err := qr.Encode(s, qr.L)
+	if err != nil {
+		return nil, nil, err
+	}
+	const qrScale = 3
+	type textEngraving struct {
+		Label     string
+		Paragraph backup.Paragraph
+	}
+	engravings := []textEngraving{
+		{"TEXT + QR", backup.Paragraph{Text: s, QR: qrc, QRScale: qrScale}},
+		{"TEXT ONLY", backup.Paragraph{Text: s}},
+		{"QR ONLY", backup.Paragraph{QR: qrc, QRScale: qrScale}},
+	}
+	var validLabels []string
+	var validEngravings []Plate
+	var lastErr error
+	for _, e := range engravings {
+		plate := backup.Text{
+			Paragraphs: []backup.Paragraph{e.Paragraph},
+			Font:       sh.Font,
+		}
+		plan := backup.EngraveText(params, plate)
+		p, err := toPlate(plan, params)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		validLabels = append(validLabels, e.Label)
+		validEngravings = append(validEngravings, p)
+	}
+	if len(validEngravings) == 0 {
+		return nil, nil, lastErr
+	}
+	return validLabels, validEngravings, nil
+}
+
+// mdmkFlow lets the operator pick an engraving variant for an md1/mk1 string
+// and engrave it, mirroring descriptorFlow.
+func mdmkFlow(ctx *Context, th *Colors, s mdmkText) {
+	labels, engravings, err := validateMdmk(ctx.Platform.EngraverParams(), string(s))
+	if err != nil {
+		// Only reached if no mode fits a plate (rare for an md1/mk1 string);
+		// like descriptorFlow's siblings, bail rather than engrave nothing.
+		return
+	}
+	cs := &ChoiceScreen{Title: "Engrave", Lead: "Choose engraving", Choices: labels}
+	for {
+		choice, ok := cs.Choose(ctx, th)
+		if !ok {
+			return
+		}
+		if NewEngraveScreen(ctx, engravings[choice]).Engrave(ctx, &engraveTheme) {
+			return
+		}
+	}
 }
 
 func backupWalletFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic) {

--- a/gui/mdmk_gui_test.go
+++ b/gui/mdmk_gui_test.go
@@ -24,6 +24,18 @@ func TestMdmkOversizeRejected(t *testing.T) {
 	ctx := NewContext(newPlatform())
 	huge := "md1" + strings.Repeat("q", 5000)
 	if _, _, err := validateMdmk(ctx.Platform.EngraverParams(), huge); err == nil {
-		t.Error("expected error for oversize input (no plate fits / QR overflow)")
+		t.Error("expected error for oversize input (QR overflow)")
+	}
+}
+
+// TestMdmkNoModeFitsRejected covers the no-plate-fits branch: ~1200 chars is
+// within QR byte capacity (so qr.Encode succeeds) but far too long to fit any
+// plate, so validateMdmk returns the toPlate error — distinct from the
+// QR-overflow path above.
+func TestMdmkNoModeFitsRejected(t *testing.T) {
+	ctx := NewContext(newPlatform())
+	big := "md1" + strings.Repeat("q", 1200)
+	if _, _, err := validateMdmk(ctx.Platform.EngraverParams(), big); err == nil {
+		t.Error("expected error: no engraving variant fits a plate")
 	}
 }

--- a/gui/mdmk_gui_test.go
+++ b/gui/mdmk_gui_test.go
@@ -1,0 +1,29 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMdmkEngrave checks that a valid md1 string lays out into engraving
+// variants (the TEXT+QR / TEXT / QR-ONLY plates mdmkFlow offers).
+func TestMdmkEngrave(t *testing.T) {
+	ctx := NewContext(newPlatform())
+	labels, plates, err := validateMdmk(ctx.Platform.EngraverParams(), "md1yqpqqxqq8xtwhw4xwn4qh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plates) == 0 || len(labels) != len(plates) {
+		t.Fatalf("got %d labels / %d plates, want >=1 of each", len(labels), len(plates))
+	}
+}
+
+// TestMdmkOversizeRejected checks that an input too large for any plate (or for
+// a QR code) is rejected with an error rather than producing a bad plate.
+func TestMdmkOversizeRejected(t *testing.T) {
+	ctx := NewContext(newPlatform())
+	huge := "md1" + strings.Repeat("q", 5000)
+	if _, _, err := validateMdmk(ctx.Platform.EngraverParams(), huge); err == nil {
+		t.Error("expected error for oversize input (no plate fits / QR overflow)")
+	}
+}

--- a/gui/scan.go
+++ b/gui/scan.go
@@ -67,10 +67,15 @@ func (s *scanner) Scan(r io.Reader) (any, error) {
 		return d, nil
 	} else if s, err := codex32.New(string(buf)); err == nil {
 		return s, nil
+	} else if codex32.ValidMD(string(buf)) || codex32.ValidMK(string(buf)) {
+		return mdmkText(buf), nil
 	} else {
 		return nil, errScanUnknownFormat
 	}
 }
+
+// mdmkText is a BCH-validated md1/mk1 string, engraved verbatim as text/QR.
+type mdmkText string
 
 type debugCommand struct {
 	Command string

--- a/gui/scan_test.go
+++ b/gui/scan_test.go
@@ -51,6 +51,16 @@ func TestScan(t *testing.T) {
 			Content: b39,
 		},
 		{
+			Name:    "md1",
+			Encoded: "md1yqpqqxqq8xtwhw4xwn4qh",
+			Content: mdmkText("md1yqpqqxqq8xtwhw4xwn4qh"),
+		},
+		{
+			Name:    "mk1",
+			Encoded: "mk1qpzg69ppsnz4v7cjv3qfjhf76k4t5pt96u0psdrqfqvll8qh7h5athg837pmkf3dpug2mmjtfel6x",
+			Content: mdmkText("mk1qpzg69ppsnz4v7cjv3qfjhf76k4t5pt96u0psdrqfqvll8qh7h5athg837pmkf3dpug2mmjtfel6x"),
+		},
+		{
 			Name:    "Command",
 			Encoded: "command: sudo-make-me-a-sandwich!",
 			Content: debugCommand{"sudo-make-me-a-sandwich!"},


### PR DESCRIPTION
## Summary
Two commits:
- **`codex32: add md1/mk1 BCH verification`** — `ValidMD`/`ValidMK` reuse the existing BCH engine with the md/mk NUMS-derived target residues and the md/mk initial residue. Pure verify (no error correction); regular + long codes for mk1, regular-only for md1.
- **`gui: recognize and engrave md1/mk1 strings`** — scan a BCH-validated md1/mk1 string into a new `mdmkText` type and engrave it verbatim as `TEXT+QR` / `TEXT` / `QR-ONLY` plates via `mdmkFlow`, mirroring the descriptor flow.

## Why
`md1` (wallet descriptor / spending policy) and `mk1` (xpubs) are bech32-style, error-correcting backup strings designed to engrave alongside a BIP-93 codex32 seed. This lets SeedHammer II engrave them directly. They are public policy / public-key material (not secrets), so NFC import is appropriate; secret material stays on the codex32 keypad.

## Test plan
- [x] `go test ./codex32/` — parity vs the reference codecs' vectors (md1, mk1 regular **and** long); tamper / all-zeros / wrong-HRP / malformed input all rejected, no panics.
- [x] `go test ./gui/` — md1/mk1 scan into `mdmkText`; engrave layout into the 3 variants; no regression in existing flows.
- [x] `go vet ./codex32/ ./gui/` and `gofmt` clean.

## Notes
- The verifier lives in `codex32/mdmk.go` to reuse the package-private BCH `engine`/generator — happy to relocate if you'd prefer a different home.
- Deeper review very welcome.

## Contact
I'm `bg002h.66` on Signal (SeedHammer community).