### PR TITLE
gui: polish BIP-39 seed-word entry (progress, match count, last-word checksum, primary-button consistency)

### DIFF
--- a/bip39/bip39.go
+++ b/bip39/bip39.go
@@ -125,6 +125,34 @@ func (m Mnemonic) FixChecksum() Mnemonic {
 	return m2
 }
 
+// LastWordCandidates returns every word that, placed in the final slot,
+// yields a checksum-valid mnemonic given the already-filled earlier words.
+// It operates on a copy and does not mutate prefix. It returns nil if
+// len(prefix)%3 != 0 or if any of the first len(prefix)-1 words is unset
+// (< 0) or out of range (>= NumWords). Otherwise it returns 8 candidates
+// for a 24-word mnemonic and 128 for a 12-word one. The final slot of
+// prefix is ignored.
+func LastWordCandidates(prefix Mnemonic) []Word {
+	if len(prefix) == 0 || len(prefix)%3 != 0 {
+		return nil
+	}
+	for _, w := range prefix[:len(prefix)-1] {
+		if w < 0 || w >= NumWords {
+			return nil
+		}
+	}
+	m := make(Mnemonic, len(prefix))
+	copy(m, prefix)
+	var cands []Word
+	for w := Word(0); w < NumWords; w++ {
+		m[len(m)-1] = w
+		if m.Valid() {
+			cands = append(cands, w)
+		}
+	}
+	return cands
+}
+
 // Entropy returns the entropy represented by the mnemonic. It
 // panics if the mnemonic is invalid.
 func (m Mnemonic) Entropy() []byte {

--- a/bip39/bip39_test.go
+++ b/bip39/bip39_test.go
@@ -207,6 +207,64 @@ var testVectors = []struct {
 	},
 }
 
+func TestLastWordCandidates(t *testing.T) {
+	build := func(n int) Mnemonic {
+		m := make(Mnemonic, n)
+		for i := range m {
+			m[i] = Word(i % int(NumWords))
+		}
+		return m.FixChecksum()
+	}
+
+	// 24-word: exactly 8 candidates, all valid, including the real last word.
+	v24 := build(24)
+	c24 := LastWordCandidates(v24)
+	if len(c24) != 8 {
+		t.Fatalf("24-word: got %d candidates, want 8", len(c24))
+	}
+	foundLast := false
+	for _, w := range c24 {
+		m := make(Mnemonic, len(v24))
+		copy(m, v24)
+		m[len(m)-1] = w
+		if !m.Valid() {
+			t.Errorf("24-word candidate %d is not checksum-valid", w)
+		}
+		if w == v24[len(v24)-1] {
+			foundLast = true
+		}
+	}
+	if !foundLast {
+		t.Errorf("24-word candidates %v do not include the real last word %d", c24, v24[len(v24)-1])
+	}
+
+	// 12-word: exactly 128 candidates.
+	v12 := build(12)
+	if c12 := LastWordCandidates(v12); len(c12) != 128 {
+		t.Fatalf("12-word: got %d candidates, want 128", len(c12))
+	}
+
+	// Incomplete prefix (an earlier word unset) -> nil.
+	bad := make(Mnemonic, len(v24))
+	copy(bad, v24)
+	bad[5] = -1
+	if got := LastWordCandidates(bad); got != nil {
+		t.Errorf("incomplete prefix: got %v, want nil", got)
+	}
+
+	// Unsupported length (len%3 != 0) -> nil.
+	if got := LastWordCandidates(make(Mnemonic, 13)); got != nil {
+		t.Errorf("len 13: got %v, want nil", got)
+	}
+
+	// Must not mutate the input's final slot.
+	before := v24[len(v24)-1]
+	_ = LastWordCandidates(v24)
+	if v24[len(v24)-1] != before {
+		t.Errorf("LastWordCandidates mutated input final slot: %d -> %d", before, v24[len(v24)-1])
+	}
+}
+
 func TestDiceToWord(t *testing.T) {
 	counts := make([]int, len(index))
 	dice := Roll{1, 1, 1, 1, 1}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -547,11 +547,35 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 	}
 	_, longest := layoutWord(nil, 24, widestWord)
 	var nvalid int
+	var cands []bip39.Word
+	candsFor := -1
+	onLastWord := func() bool { return selected == len(mnemonic)-1 && cands != nil }
+	updateKeys := func(frag string) int {
+		if onLastWord() {
+			return updateValidCandidateKeys(cands, frag, kbd.allKeys)
+		}
+		return updateValidBIP39Keys(frag, kbd.allKeys)
+	}
+	completeWord := func(frag string, nv int) (bip39.Word, bool) {
+		if onLastWord() {
+			return completeCandidateWord(cands, frag, nv)
+		}
+		return completeBIP39Word(frag, nv)
+	}
 	for !ctx.Done {
-		for kbd.Update(ctx) {
-			nvalid = updateValidBIP39Keys(kbd.Fragment, kbd.allKeys)
+		if selected == len(mnemonic)-1 && candsFor != selected {
+			cands = bip39.LastWordCandidates(mnemonic)
+			candsFor = selected
+			nvalid = updateKeys(kbd.Fragment)
 			wordLabel = kbd.Fragment
-			if completedWord, complete := completeBIP39Word(wordLabel, nvalid); complete {
+			if cw, ok := completeWord(kbd.Fragment, nvalid); ok {
+				wordLabel = bip39.LabelFor(cw)
+			}
+		}
+		for kbd.Update(ctx) {
+			nvalid = updateKeys(kbd.Fragment)
+			wordLabel = kbd.Fragment
+			if completedWord, ok := completeWord(wordLabel, nvalid); ok {
 				wordLabel = bip39.LabelFor(completedWord)
 			}
 		}
@@ -559,8 +583,8 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 			return
 		}
 		for okBtn.Clicked(ctx) {
-			w, complete := completeBIP39Word(kbd.Fragment, nvalid)
-			if !complete {
+			w, ok := completeWord(kbd.Fragment, nvalid)
+			if !ok {
 				continue
 			}
 			kbd.Clear()
@@ -603,7 +627,7 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 		).Offset(wordOff)
 
 		var countOp op.Op
-		if len(kbd.Fragment) > 0 {
+		if len(kbd.Fragment) > 0 || onLastWord() {
 			noun := "matches"
 			if nvalid == 1 {
 				noun = "match"
@@ -617,7 +641,7 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 		}
 
 		nav, _ := layoutNavigation(&ctx.B, th, dims, []NavButton{{Clickable: backBtn, Style: StyleSecondary, Icon: assets.IconBack}}...)
-		if _, complete := completeBIP39Word(kbd.Fragment, nvalid); complete {
+		if _, ok := completeWord(kbd.Fragment, nvalid); ok {
 			nav2, _ := layoutNavigation(&ctx.B, th, dims, []NavButton{{Clickable: okBtn, Style: StylePrimary, Icon: assets.IconCheckmark}}...)
 			nav = op.Layer(
 				nav,

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -609,7 +609,7 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 				nav2,
 			)
 		}
-		title, _ := layoutTitle(ctx, dims.X, th.Text, "Input Words")
+		title, _ := layoutTitlef(ctx, dims.X, th.Text, "Word %d of %d", selected+1, len(mnemonic))
 		ctx.Frame(op.Layer(
 			kbdOp,
 			txtBg,

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -934,6 +934,52 @@ func updateValidSLIP39Keys(frag string, keys []keyboardKey) int {
 	return nvalid
 }
 
+// completeCandidateWord reports completion against a fixed candidate set
+// (the checksum-valid last words). Unlike completeBIP39Word it never
+// completes on a non-candidate label, so a checksum-invalid final word can
+// never be accepted.
+func completeCandidateWord(cands []bip39.Word, frag string, nvalid int) (bip39.Word, bool) {
+	for _, w := range cands {
+		if frag == bip39.LabelFor(w) {
+			return w, true
+		}
+	}
+	if nvalid == 1 {
+		for _, w := range cands {
+			if strings.HasPrefix(bip39.LabelFor(w), frag) {
+				return w, true
+			}
+		}
+	}
+	return -1, false
+}
+
+// updateValidCandidateKeys restricts the keyboard to letters that extend the
+// fragment toward one of the candidate words, mirroring updateValidBIP39Keys
+// but over a fixed candidate set. Returns the number of still-matching
+// candidates.
+func updateValidCandidateKeys(cands []bip39.Word, frag string, keys []keyboardKey) int {
+	mask := ^uint32(0)
+	nvalid := 0
+	for _, w := range cands {
+		label := bip39.LabelFor(w)
+		if !strings.HasPrefix(label, frag) {
+			continue
+		}
+		nvalid++
+		suffix := label[len(frag):]
+		if len(suffix) > 0 {
+			idx := unicode.ToLower(rune(suffix[0])) - 'a'
+			mask &^= 1 << idx
+		}
+	}
+	if nvalid == 1 {
+		mask = ^uint32(0)
+	}
+	updateValidKeys(mask, keys)
+	return nvalid
+}
+
 func updateValidKeys(mask uint32, keys []keyboardKey) {
 	for i := range keys {
 		key := &keys[i]

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -592,6 +592,7 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 		r.Min.X -= buttonPadX
 		r.Max.X += buttonPadX
 		top, _ := content.CutBottom(kbdsz.Y)
+		wordOff := top.Center(longest)
 		word, _ := layoutWord(&ctx.B, selected+1, wordLabel)
 		txtBg := op.Layer(
 			word,
@@ -599,7 +600,21 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 				op.Color(&ctx.B, th.Text),
 				op.RoundedRect2(&ctx.B, r, cornerRadius),
 			),
-		).Offset(top.Center(longest))
+		).Offset(wordOff)
+
+		var countOp op.Op
+		if len(kbd.Fragment) > 0 {
+			noun := "matches"
+			if nvalid == 1 {
+				noun = "match"
+			}
+			cl, csz := widget.Labelf(&ctx.B, ctx.Styles.word, th.Text, "%d %s", nvalid, noun)
+			countY := wordOff.Y + longest.Y + 8
+			if lim := top.Max.Y - csz.Y; countY > lim { // clamp so the count never overlaps the keyboard
+				countY = lim
+			}
+			countOp = cl.Offset(image.Pt((dims.X-csz.X)/2, countY))
+		}
 
 		nav, _ := layoutNavigation(&ctx.B, th, dims, []NavButton{{Clickable: backBtn, Style: StyleSecondary, Icon: assets.IconBack}}...)
 		if _, complete := completeBIP39Word(kbd.Fragment, nvalid); complete {
@@ -613,6 +628,7 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 		ctx.Frame(op.Layer(
 			kbdOp,
 			txtBg,
+			countOp,
 			nav,
 			title,
 			op.Color(&ctx.B, th.Background),

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -540,7 +540,7 @@ func inputWordsFlow(ctx *Context, th *Colors, mnemonic bip39.Mnemonic, selected 
 	kbd := NewKeyboard(ctx, wordKeys)
 	wordLabel := ""
 	backBtn := &Clickable{Button: Button1}
-	okBtn := &Clickable{Button: Button2}
+	okBtn := &Clickable{Button: Button3}
 	layoutWord := func(buf *op.Buffer, n int, word string) (op.Op, image.Point) {
 		style := ctx.Styles.word
 		return widget.Labelf(buf, style, th.Background, "%2d: %s", n, word)
@@ -625,7 +625,7 @@ func inputCodex32Flow(ctx *Context, th *Colors) (codex32.String, bool) {
 
 	kbd := NewKeyboard(ctx, alph)
 	backBtn := &Clickable{Button: Button1}
-	okBtn := &Clickable{Button: Button2}
+	okBtn := &Clickable{Button: Button3}
 	var share codex32.String
 	valid := false
 	for !ctx.Done {
@@ -685,7 +685,7 @@ func inputSLIP39Flow(ctx *Context, th *Colors, mnemonic slip39words.Mnemonic, se
 	kbd := NewKeyboard(ctx, wordKeys)
 	wordLabel := ""
 	backBtn := &Clickable{Button: Button1}
-	okBtn := &Clickable{Button: Button2}
+	okBtn := &Clickable{Button: Button3}
 	layoutWord := func(b *op.Buffer, n int, word string) (op.Op, image.Point) {
 		style := ctx.Styles.word
 		return widget.Labelf(b, style, th.Background, "%2d: %s", n, word)
@@ -949,7 +949,7 @@ func (k *Keyboard) Update(ctx *Context) bool {
 		}
 	}
 	for {
-		e, ok := k.inp.Next(ctx, ButtonFilter(Left), ButtonFilter(Right), ButtonFilter(Up), ButtonFilter(Down), ButtonFilter(Center), RuneFilter(), ButtonFilter(Button3))
+		e, ok := k.inp.Next(ctx, ButtonFilter(Left), ButtonFilter(Right), ButtonFilter(Up), ButtonFilter(Down), ButtonFilter(Center), RuneFilter())
 		if !ok {
 			break
 		}
@@ -1006,7 +1006,7 @@ func (k *Keyboard) Update(ctx *Context) bool {
 						break
 					}
 				}
-			case Center, Button3:
+			case Center:
 				k.rune()
 				return true
 			}

--- a/gui/gui_test.go
+++ b/gui/gui_test.go
@@ -589,3 +589,79 @@ func TestUpdateValidCandidateKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestWordFlowLastWord24(t *testing.T) {
+	v := validMnemonic(24)
+
+	// Candidate count visible on entering the last word (empty fragment).
+	{
+		ctx := NewContext(newPlatform())
+		m := make(bip39.Mnemonic, 24)
+		copy(m, v)
+		m[23] = -1 // last slot unset; first 23 are valid
+		frame, quit := runUI(ctx, func() {
+			inputWordsFlow(ctx, &descriptorTheme, m, 23)
+		})
+		content, ok := frame()
+		quit()
+		if !ok {
+			t.Fatal("no frame at last word")
+		}
+		if !uiContains(content, "8 matches") {
+			t.Errorf("expected %q at last word; got %q", "8 matches", content)
+		}
+	}
+
+	// Typing the correct last word commits it.
+	{
+		ctx := NewContext(newPlatform())
+		m := make(bip39.Mnemonic, 24)
+		copy(m, v)
+		m[23] = -1
+		want := v[23]
+		runes(&ctx.Router, bip39.LabelFor(want))
+		click(&ctx.Router, Button3)
+		inputWordsFlow(ctx, &descriptorTheme, m, 23)
+		if m[23] != want {
+			t.Errorf("last word committed %d (%q), want %d (%q)",
+				m[23], bip39.LabelFor(m[23]), want, bip39.LabelFor(want))
+		}
+	}
+}
+
+func TestWordFlowLastWord12(t *testing.T) {
+	v := validMnemonic(12)
+
+	{
+		ctx := NewContext(newPlatform())
+		m := make(bip39.Mnemonic, 12)
+		copy(m, v)
+		m[11] = -1
+		frame, quit := runUI(ctx, func() {
+			inputWordsFlow(ctx, &descriptorTheme, m, 11)
+		})
+		content, ok := frame()
+		quit()
+		if !ok {
+			t.Fatal("no frame at last word")
+		}
+		if !uiContains(content, "128 matches") {
+			t.Errorf("expected %q at last word; got %q", "128 matches", content)
+		}
+	}
+
+	{
+		ctx := NewContext(newPlatform())
+		m := make(bip39.Mnemonic, 12)
+		copy(m, v)
+		m[11] = -1
+		want := v[11]
+		runes(&ctx.Router, bip39.LabelFor(want))
+		click(&ctx.Router, Button3)
+		inputWordsFlow(ctx, &descriptorTheme, m, 11)
+		if m[11] != want {
+			t.Errorf("last word committed %d (%q), want %d (%q)",
+				m[11], bip39.LabelFor(m[11]), want, bip39.LabelFor(want))
+		}
+	}
+}

--- a/gui/gui_test.go
+++ b/gui/gui_test.go
@@ -278,7 +278,7 @@ func TestWordKeyboardScreen(t *testing.T) {
 	for i := range bip39.NumWords {
 		w := bip39.LabelFor(i)
 		runes(&ctx.Router, w)
-		click(&ctx.Router, Button2)
+		click(&ctx.Router, Button3)
 		m := make(bip39.Mnemonic, 1)
 		inputWordsFlow(ctx, &descriptorTheme, m, 0)
 		if got := bip39.LabelFor(m[0]); got != w {

--- a/gui/gui_test.go
+++ b/gui/gui_test.go
@@ -497,3 +497,31 @@ func TestWordFlowProgressTitle(t *testing.T) {
 		t.Errorf("title missing %q; got %q", "Word 1 of 24", content)
 	}
 }
+
+func TestWordFlowMatchCount(t *testing.T) {
+	ctx := NewContext(newPlatform())
+	m := emptyBIP39Mnemonic(24)
+	frame, quit := runUI(ctx, func() {
+		inputWordsFlow(ctx, &descriptorTheme, m, 0)
+	})
+	defer quit()
+
+	// Empty fragment: no match count shown.
+	content, ok := frame()
+	if !ok {
+		t.Fatal("no frame")
+	}
+	if uiContains(content, "match") {
+		t.Errorf("match count shown on empty fragment; got %q", content)
+	}
+
+	// Type a complete word (ABANDON) -> exactly one match.
+	runes(&ctx.Router, "abandon")
+	content, ok = frame()
+	if !ok {
+		t.Fatal("no frame after typing")
+	}
+	if !uiContains(content, "1 match") {
+		t.Errorf("expected %q; got %q", "1 match", content)
+	}
+}

--- a/gui/gui_test.go
+++ b/gui/gui_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"testing/synctest"
 	"time"
+	"unicode"
 
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
@@ -523,5 +524,68 @@ func TestWordFlowMatchCount(t *testing.T) {
 	}
 	if !uiContains(content, "1 match") {
 		t.Errorf("expected %q; got %q", "1 match", content)
+	}
+}
+
+func validMnemonic(n int) bip39.Mnemonic {
+	m := make(bip39.Mnemonic, n)
+	for i := range m {
+		m[i] = bip39.Word(i % int(bip39.NumWords))
+	}
+	return m.FixChecksum()
+}
+
+func TestCompleteCandidateWord(t *testing.T) {
+	v := validMnemonic(24)
+	cands := bip39.LastWordCandidates(v)
+	if len(cands) != 8 {
+		t.Fatalf("expected 8 candidates, got %d", len(cands))
+	}
+	last := v[len(v)-1]
+
+	// Exact candidate label completes to that word.
+	if w, ok := completeCandidateWord(cands, bip39.LabelFor(last), 1); !ok || w != last {
+		t.Errorf("exact candidate: got (%d,%v), want (%d,true)", w, ok, last)
+	}
+
+	// A non-candidate BIP-39 word must NOT complete to ITSELF (the I2 hole).
+	inCands := map[bip39.Word]bool{}
+	for _, w := range cands {
+		inCands[w] = true
+	}
+	var nonCand bip39.Word = -1
+	for w := bip39.Word(0); w < bip39.NumWords; w++ {
+		if !inCands[w] {
+			nonCand = w
+			break
+		}
+	}
+	if w, ok := completeCandidateWord(cands, bip39.LabelFor(nonCand), 1); ok && w == nonCand {
+		t.Errorf("non-candidate word %q completed to itself but must not", bip39.LabelFor(nonCand))
+	}
+}
+
+func TestUpdateValidCandidateKeys(t *testing.T) {
+	ctx := NewContext(newPlatform())
+	v := validMnemonic(24)
+	cands := bip39.LastWordCandidates(v)
+
+	wantEnabled := map[rune]bool{}
+	for _, w := range cands {
+		label := bip39.LabelFor(w)
+		wantEnabled[unicode.ToLower(rune(label[0]))] = true
+	}
+
+	kbd := NewKeyboard(ctx, wordKeys)
+	updateValidCandidateKeys(cands, "", kbd.allKeys)
+	for i := range kbd.allKeys {
+		key := &kbd.allKeys[i]
+		if key.r == '⌫' {
+			continue
+		}
+		enabled := !key.disabled
+		if enabled != wantEnabled[key.r] {
+			t.Errorf("key %q: enabled=%v, want %v", key.r, enabled, wantEnabled[key.r])
+		}
 	}
 }

--- a/gui/gui_test.go
+++ b/gui/gui_test.go
@@ -481,3 +481,19 @@ func uiContains(content, str string) bool {
 	clean := strings.ReplaceAll(strings.ToLower(str), " ", "")
 	return strings.Contains(txt, clean)
 }
+
+func TestWordFlowProgressTitle(t *testing.T) {
+	ctx := NewContext(newPlatform())
+	m := emptyBIP39Mnemonic(24)
+	frame, quit := runUI(ctx, func() {
+		inputWordsFlow(ctx, &descriptorTheme, m, 0)
+	})
+	defer quit()
+	content, ok := frame()
+	if !ok {
+		t.Fatal("inputWordsFlow produced no frame")
+	}
+	if !uiContains(content, "Word 1 of 24") {
+		t.Errorf("title missing %q; got %q", "Word 1 of 24", content)
+	}
+}


### PR DESCRIPTION
## Summary

Polishes the on-device **BIP-39 seed-word entry** flow. Five small, generic improvements; no new dependencies; host-tested. Intentionally minimal and isolated (branched off `main`, BIP-39 entry only — no format or feature additions), to be easy to review.

- **Per-word progress** — the title shows `Word N of 24` instead of a static "Input Words".
- **Remaining-match count** — while typing a word, shows e.g. `12 matches` / `1 match`, surfacing the count already computed for the key-dimming.
- **Last-word checksum assist** — on the final word, the keyboard is restricted to the checksum-valid candidate words (exactly **8** for a 24-word seed, **128** for a 12-word one) via a new `bip39.LastWordCandidates`, so any completed last word is checksum-valid. This removes the most common "Invalid Seed" dead-end. The `SeedScreen.Confirm` `mnemonic.Valid()` check remains the backstop for the earlier words.
- **Primary-button consistency** — the word-accept action moves to **Button3**, matching every other screen (`ChoiceScreen`, `ErrorScreen`, `SeedScreen`, …).

### Behavior change worth flagging

To free Button3 for the screen-level accept, the on-screen keyboard now commits the focused key on **Center only** (the D-pad center) — Button3 no longer doubles as a key-commit. Center still commits the focused key; per-key touch still commits. Applied uniformly across the word / codex32 / SLIP-39 input flows for consistency (the latter two are menu-disabled here; the change is forward-consistency only).

## Implementation notes

- `bip39.LastWordCandidates(prefix)` is a pure helper that brute-forces `Valid()` over the 2048-word list (runs once per last-word entry, memoized), guarding a partial/out-of-range prefix by returning `nil` (safe fallback to the full keyboard — no panic, no lock-out). Unit-tested for the 8 (24-word) / 128 (12-word) counts and non-mutation of its input.
- The last-word completion is candidate-scoped: it never autocompletes to a non-candidate word, so a checksum-invalid final word can't be accepted via the assisted path.
- Case handling mirrors the existing `updateValidBIP39Keys` (uppercase labels ↔ lowercase keys).

## Test plan

- [x] `go test ./gui/... ./bip39/...` (host) — all pass, including new tests for the helper, the progress title, the match count, the Button3 accept, and the 12-/24-word last-word flows.
- [x] `go vet` / `gofmt` clean.
- [ ] On-device touch/D-pad QA — pending hardware on my end.

Commits are signed and carry DCO `Signed-off-by`.
